### PR TITLE
cli improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ Supported languages: coffeescript, csharp, ecmascript5, ecmascript6, java, php, 
 Examples:
   $ puml2code -i input.puml -l ecmascript6 -o out
   $ puml2code -h
+Use DEBUG=puml2code env variable to get traces. Example:
+  $ DEBUG=puml2code puml2code -i input.puml
 ```
 
 e.g.
@@ -93,6 +95,7 @@ class Scheduler {
 }
 ```
 See more output examples [here](examples)
+
 
 ### LICENSE:
 [MIT](LICENSE)

--- a/README.md
+++ b/README.md
@@ -43,13 +43,13 @@ Options:
   -V, --version       output the version number
   -i, --input [file]  input .puml file, or "stdin"
   -l, --lang [lang]   Optional output source code language (default: "ecmascript6")
-  -o, --out [path]    Output path
+  -o, --out [path]    Output path. When not given output is printed to console.
   -h, --help          output usage information
 
 Supported languages: coffeescript, csharp, ecmascript5, ecmascript6, java, php, python, ruby, typescript
 
 Examples:
-  $ puml2code -i input.puml -l ecmascript6 -o out
+  $ puml2code -i input.puml -l ecmascript6
   $ puml2code -h
 Use DEBUG=puml2code env variable to get traces. Example:
   $ DEBUG=puml2code puml2code -i input.puml

--- a/README.md
+++ b/README.md
@@ -36,15 +36,21 @@ $ npm i -g puml2code
 ### Usage
 
 ```
-$ Usage: cli [options]
+$ puml2code -h
+Usage: puml2code [options]
 
 Options:
   -V, --version       output the version number
-  -i, --input [file]  input .puml file
-  -l, --lang [lang]   select output code language (default: "es6")
-  -o, --out [path]    Output path (default: "console")
+  -i, --input [file]  input .puml file, or "stdin"
+  -l, --lang [lang]   Optional output source code language (default: "ecmascript6")
+  -o, --out [path]    Output path
   -h, --help          output usage information
 
+Supported languages: coffeescript, csharp, ecmascript5, ecmascript6, java, php, python, ruby, typescript
+
+Examples:
+  $ puml2code -i input.puml -l ecmascript6 -o out
+  $ puml2code -h
 ```
 
 e.g.

--- a/package-lock.json
+++ b/package-lock.json
@@ -485,12 +485,18 @@
       "dev": true
     },
     "debug": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-      "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-      "dev": true,
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+      "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
       "requires": {
-        "ms": "2.0.0"
+        "ms": "^2.1.1"
+      },
+      "dependencies": {
+        "ms": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
+        }
       }
     },
     "deep-eql": {
@@ -1364,6 +1370,21 @@
         "source-map": "^0.5.3"
       },
       "dependencies": {
+        "debug": {
+          "version": "3.2.6",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "ms": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+          "dev": true
+        },
         "source-map": {
           "version": "0.5.7",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
@@ -1545,6 +1566,15 @@
           "resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
           "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==",
           "dev": true
+        },
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "bluebird": "^3.5.3",
     "camelcase": "^5.0.0",
     "commander": "^2.19.0",
+    "debug": "^4.1.1",
     "handlebars": "^4.1.0",
     "lodash": "^4.17.11",
     "pegjs": "^0.10.0"

--- a/src/Output.js
+++ b/src/Output.js
@@ -1,6 +1,6 @@
 // native modules
 const { join } = require('path');
-const { writeFile } = require('fs');
+const { writeFile, mkdir } = require('fs');
 // 3rd party modules
 const Promise = require('bluebird');
 const _ = require('lodash');
@@ -19,7 +19,15 @@ class Output {
     });
   }
 
+  static mkdir(path) {
+    return new Promise(
+      (resolve, reject) => mkdir(path,
+        err => ((err && err.code !== 'EEXIST') ? reject(err) : resolve())),
+    );
+  }
+
   async save(path) {
+    await Output.mkdir(path); // ensure that folder exists or create it
     this.logger.debug(`Write files ${_.map(this._files, (content, file) => file)} to path: ${path}`);
     const writer = (content, file) => Promise.fromCallback(cb => writeFile(join(path, file), content, cb));
     const pendings = _.map(this._files, writer);

--- a/src/cli.js
+++ b/src/cli.js
@@ -19,6 +19,8 @@ const parseArgs = argv => program
     print('Examples:');
     print('  $ puml2code -i input.puml -l ecmascript6 -o out');
     print('  $ puml2code -h');
+    print('Use DEBUG=puml2code env variable to get traces. Example:');
+    print('  $ DEBUG=puml2code puml2code -i input.puml');
   })
   .parse(argv);
 
@@ -44,8 +46,9 @@ const getSource = (args) => {
 };
 
 const execute = async (argv = process.argv, printer = console.log) => { // eslint-disable-line no-console
+  let args = {removeAllListeners: () => {}};
   try {
-    const args = parseArgs(argv);
+    args = parseArgs(argv);
     const puml = await getSource(args);
     const output = await puml.generate(args.lang);
     if (args.out) {
@@ -54,9 +57,11 @@ const execute = async (argv = process.argv, printer = console.log) => { // eslin
       output.print(printer);
     }
     logger.debug('ready');
+    args.removeAllListeners();
     return 0;
   } catch (error) {
     logger.error(error);
+    args.removeAllListeners();
     return 1;
   }
 };

--- a/src/cli.js
+++ b/src/cli.js
@@ -10,14 +10,14 @@ const parseArgs = argv => program
   .version('0.1.0')
   .option('-i, --input [file]', 'input .puml file, or "stdin"')
   .option('-l, --lang [lang]', 'Optional output source code language', options, 'ecmascript6')
-  .option('-o, --out [path]', 'Output path')
+  .option('-o, --out [path]', 'Output path. When not given output is printed to console.')
   .on('--help', () => {
     const print = console.log; // eslint-disable-line no-console
     print('');
     print(`Supported languages: ${Puml.languages.join(', ')}`);
     print('');
     print('Examples:');
-    print('  $ puml2code -i input.puml -l ecmascript6 -o out');
+    print('  $ puml2code -i input.puml -l ecmascript6');
     print('  $ puml2code -h');
     print('Use DEBUG=puml2code env variable to get traces. Example:');
     print('  $ DEBUG=puml2code puml2code -i input.puml');

--- a/src/cli.js
+++ b/src/cli.js
@@ -46,7 +46,7 @@ const getSource = (args) => {
 };
 
 const execute = async (argv = process.argv, printer = console.log) => { // eslint-disable-line no-console
-  let args = {removeAllListeners: () => {}};
+  let args = { removeAllListeners: () => {} };
   try {
     args = parseArgs(argv);
     const puml = await getSource(args);

--- a/src/logger.js
+++ b/src/logger.js
@@ -1,6 +1,8 @@
+const debug = require('debug')('puml2code');
+
 const nullLogger = new Proxy({}, {
   get: (m, level) => (line) => { // eslint-disable-line no-unused-vars
-    console.log(`[${level}] ${line}`); // eslint-disable-line no-console
+    debug(`[${level}] ${line}`);
   },
 });
 


### PR DESCRIPTION
* `-i --input` is now mandatory. `stdin` as value takes input from stdin pipe
* `--out` is optional. Without tool just print output to console
* create folder if not exists
* more help text
* use `debug` module for traces
* add examples for help and readme
* remove commander listeners end of execute to avoid tests warnings